### PR TITLE
fix: correct editable-install backend and part/product rename handling

### DIFF
--- a/catia_mcp/tools/document.py
+++ b/catia_mcp/tools/document.py
@@ -159,21 +159,35 @@ class DocumentTools:
         self.conn.ensure_connected()
         docs = self.conn.documents
         doc = docs.Add("Part")
+        rename_note = ""
         if name:
-            doc.Part.Name = name
+            try:
+                doc.Part.Name = name
+            except Exception as e:
+                rename_note = f" (rename to '{name}' not supported by this CATIA version: {e})"
         part_name = doc.Part.Name
         self.conn.refresh_display()
-        return f"Created new Part document: '{part_name}'"
+        return f"Created new Part document: '{part_name}'{rename_note}"
 
     def _new_product(self, name: str | None = None) -> str:
         self.conn.ensure_connected()
         docs = self.conn.documents
         doc = docs.Add("Product")
+        rename_note = ""
         if name:
-            doc.Product.Name = name
+            try:
+                doc.Product.Name = name
+            except Exception as e:
+                rename_note = f" (rename to '{name}' not supported by this CATIA version: {e})"
+            else:
+                if doc.Product.Name != name:
+                    rename_note = (
+                        f" (requested name '{name}' was not applied by CATIA; "
+                        f"kept '{doc.Product.Name}')"
+                    )
         product_name = doc.Product.Name
         self.conn.refresh_display()
-        return f"Created new Product (assembly) document: '{product_name}'"
+        return f"Created new Product (assembly) document: '{product_name}'{rename_note}"
 
     def _open_document(self, file_path: str) -> str:
         self.conn.ensure_connected()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "catia-v5-mcp-server"


### PR DESCRIPTION
- pyproject.toml pointed at a nonexistent setuptools build-backend entry point, breaking `pip install -e .` on current setuptools.
- catia_new_part crashed when given a name because Part.Name is read-only in this CATIA version; now it creates the part and reports the rename as unsupported instead of failing the call.
- catia_new_product silently reported the requested name as applied even when CATIA ignored the assignment; now it reads the name back and reports what CATIA actually kept.