### PR TITLE
Add production-grade CATIA V5 agent skills

### DIFF
--- a/.claude/skills/catia-v5-mcp-maintainer/SKILL.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: catia-v5-mcp-maintainer
+description: Maintain daiemon12/catia-v5-mcp-server against a production reliability contract. Use when changing tool schemas or implementations, COM execution, session health, structured results, object handles, topology references, recovery, diagnostics, CAA bridge integration, or regression evaluation. Requires source-first changes, truthful schemas, deterministic failure behavior, and live CATIA validation for COM/BRep semantics.
+compatibility: Python 3.10+; Windows with pywin32 and CATIA V5 for live validation. Source-level tests may run cross-platform when CATIA imports are isolated.
+metadata:
+  version: "1.1.0"
+  locale: "en-US"
+  target-repository: "daiemon12/catia-v5-mcp-server"
+---
+
+# CATIA V5 MCP Maintainer
+
+Use this skill when changing the target MCP server itself. Production support is a contract between schema, implementation, runtime behavior, diagnostics, recovery, and tests. Tool count alone is not a reliability metric.
+
+## Mandatory engineering rules
+
+1. Inspect repository-local schema and implementation before changing or documenting a tool.
+2. Keep public schemas truthful: every advertised input must be consumed with defined semantics or removed/deprecated.
+3. Serialize CATIA COM access through a dedicated STA execution boundary; do not let arbitrary MCP request threads use shared COM objects directly.
+4. Return structured results with deterministic success/failure classification. Human-readable text is a secondary representation, not the primary protocol.
+5. Separate CATIA update success from intended geometry effect.
+6. Give material-changing operations measurable postconditions and explicit no-effect/wrong-effect failures.
+7. Use server-managed handles for document/model objects rather than relying on display names or long mutable paths.
+8. Use generation/version-scoped topology references and reject stale references before mutation.
+9. Provide deterministic recovery for supported reversible operations. Do not depend on localized UI command strings for Undo.
+10. Treat modal dialogs, timeouts, and indeterminate COM completion as session-health events, not ordinary retryable exceptions.
+11. Keep CAA/native access behind typed adapters; do not expose raw native/COM pointers across the MCP boundary.
+12. Do not classify a capability as production-supported until schema tests, failure-path tests, and relevant live CATIA validation pass.
+
+## Reference loading
+
+Read `references/repository-contract-gaps.md` before modifying an existing tool or capability group.
+
+Read `references/production-architecture.md` before changing COM/session execution, object lifecycle, recovery, topology, diagnostics, or CAA integration.
+
+Read `references/result-contract.md` before adding or changing tool outputs/errors.
+
+Read `references/test-strategy.md` before accepting a behavior change.
+
+Read `references/production-readiness-checklist.md` when assessing support level across capability groups.
+
+## Source-first change process
+
+For each change:
+
+1. Inspect the exact schema, dispatch path, implementation, and relevant helper functions.
+2. Write the intended behavioral contract: inputs, units, target semantics, preconditions, effects, errors, and recovery metadata.
+3. Add or adjust an offline contract/failure test that can detect the current defect where possible.
+4. Implement the smallest deterministic change that satisfies the contract.
+5. Preserve a public tool name only when backward semantics remain compatible; otherwise version, narrow, or deprecate the contract explicitly.
+6. Add a live CATIA probe for any behavior that mocks cannot establish, especially COM apartment behavior, CATIA API signatures, BRep references, update diagnostics, and modal UI.
+7. Update capability classification only after the implementation and validation evidence agree.
+
+## Runtime execution contract
+
+The target runtime should separate asynchronous MCP transport from CATIA execution:
+
+`MCP request -> typed validation -> operation orchestrator -> serialized STA worker -> CATIA Automation / optional CAA adapter -> result verification`
+
+The worker owns COM initialization and COM object resolution on its own STA thread. Request handlers enqueue logical operations and await structured results.
+
+Do not transfer apartment-bound raw COM objects to request threads. Store logical handles and resolve them on the worker.
+
+## Session-health contract
+
+Use explicit session health such as:
+
+- `healthy`: CATIA state is known and mutations are allowed;
+- `blocked`: a known modal/blocked condition prevents safe calls;
+- `unknown`: call completion or model state cannot be established;
+- `disconnected`: no active CATIA connection.
+
+A timeout does not prove an in-flight COM call was cancelled. If completion is indeterminate, transition to `unknown` or `blocked` and reject further mutations until health and model state are re-established.
+
+## Tool contract
+
+Each engineering-intent tool should define:
+
+- narrow typed inputs;
+- units and enum semantics;
+- deterministic target references;
+- precondition checks;
+- mutation/update behavior;
+- measurable effects;
+- structured data/result fields;
+- typed failure codes;
+- recovery metadata where applicable;
+- tests for success, failure, and no-effect/wrong-effect behavior.
+
+A mutation tool must not return only a phrase such as "created successfully" when design correctness can be measured.
+
+## Schema integrity
+
+A schema field is part of the public contract. If implementation ignores an advertised input, choose one of two actions:
+
+- implement the input semantics and validate them; or
+- remove/deprecate the input and narrow the capability description.
+
+Documentation must not be used to compensate for an ignored runtime input.
+
+## Geometry-effect contract
+
+For a tool expected to add/remove material:
+
+1. capture pre-operation update/measurement state;
+2. perform the mutation on the STA worker;
+3. update CATIA;
+4. collect post-operation measurement state;
+5. classify effect;
+6. return structured effect metadata.
+
+At minimum support typed outcomes for `FEATURE_NO_EFFECT`, `WRONG_GEOMETRY_EFFECT`, and `UPDATE_FAILED` when applicable.
+
+## Object-handle contract
+
+Expose opaque logical handles for session objects such as documents, bodies, sketches, features, and parameters. The handle registry should track owning document/session and object validity.
+
+After document close/reload/session reset, affected handles must fail deterministically, for example with `STALE_HANDLE` or `OBJECT_NOT_FOUND`. Never silently rebind a stale handle by display name.
+
+## Topology-reference contract
+
+Topology references are server-layer abstractions, not durable native CATIA IDs. Treat the external token format as opaque.
+
+A topology record should include:
+
+- token;
+- face/edge kind;
+- owning document/body;
+- topology generation/version;
+- geometric descriptors;
+- resolver metadata required to reconstruct an exact CATIA/CAA reference.
+
+Every shape-changing mutation increments or invalidates the topology generation. A token from an older generation must return `STALE_TOPOLOGY_TOKEN` before feature creation. Never fall back to the same numeric index in a changed topology.
+
+## Recovery contract
+
+Use an operation journal or equivalent deterministic recovery record. This is a logical recovery mechanism, not an ACID transaction and not a claim of CATIA-native atomicity.
+
+Record, as applicable:
+
+- created feature handle and deletion strategy;
+- parameter old/new value;
+- document/model generation before and after;
+- operation group identity for multi-step intent;
+- measurements used to verify rollback.
+
+Rollback must run in reverse order, update CATIA, and verify restoration where measurable.
+
+## Modal-dialog contract
+
+Detect/report blocking CATIA modal dialogs around fragile or long-running calls. Auto-close only an explicit allowlist of non-destructive dialogs. Return dialog metadata and session-health impact. Do not invoke arbitrary buttons based on caption similarity.
+
+## Diagnostics and CAA
+
+Automation exceptions are insufficient for advanced repair. Expose the deepest available diagnostics without inventing native meaning.
+
+When a CAA bridge is present:
+
+- keep the bridge behind a typed JSON/Automation boundary;
+- return locale-independent feature types where possible;
+- return native CATIA update diagnostics;
+- provide exact BRep reference helpers for topology-consuming features;
+- preserve lower-layer failure state without re-wrapping it as success.
+
+When a CAA bridge is absent, return the limitation explicitly rather than synthesizing native diagnostic text.
+
+## Validation requirement
+
+Offline tests establish schema/orchestration contracts. Live CATIA probes establish actual COM/API/BRep behavior. Agent task evaluations establish end-to-end capability.
+
+All three levels are required before broad production-support claims for features that depend on CATIA runtime semantics.
+
+## Acceptance criteria
+
+A production-supporting change is complete only when all applicable conditions hold:
+
+- schema and implementation semantics agree;
+- structured failure state propagates unchanged across layers;
+- no advertised input is silently ignored;
+- session/thread rules are preserved;
+- stale handles/tokens fail deterministically;
+- update success and geometry-effect success are evaluated separately;
+- success, failure, and no-effect/wrong-effect paths are tested;
+- relevant live CATIA validation passes, or the capability remains explicitly non-production-validated;
+- documentation states the supported contract and limitations without overstating them.

--- a/.claude/skills/catia-v5-mcp-maintainer/evals/evals.json
+++ b/.claude/skills/catia-v5-mcp-maintainer/evals/evals.json
@@ -1,0 +1,79 @@
+{
+  "skill": "catia-v5-mcp-maintainer",
+  "version": "1.1.0",
+  "locale": "en-US",
+  "cases": [
+    {
+      "id": "maint-001-schema-integrity",
+      "prompt": "Make catia_hole production-safe when the schema advertises hole types the implementation does not fully implement.",
+      "assertions": [
+        "Inspects schema and implementation first",
+        "Implements and validates advertised semantics or narrows/deprecates the schema",
+        "Does not leave ignored inputs as supported",
+        "Adds failure-path and live-CATIA validation for implemented CATIA semantics"
+      ]
+    },
+    {
+      "id": "maint-002-sta-session",
+      "prompt": "Make shared CATIA access safe when MCP requests overlap.",
+      "assertions": [
+        "Introduces a dedicated serialized STA worker",
+        "Does not pass raw COM objects across apartment/thread boundaries",
+        "Async handlers enqueue logical operations",
+        "Defines session-health transitions and tests them"
+      ]
+    },
+    {
+      "id": "maint-003-no-effect",
+      "prompt": "Prevent Pocket from reporting design success when it updates but removes no material.",
+      "assertions": [
+        "Captures pre/post measurements",
+        "Keeps update success separate from effect success",
+        "Returns FEATURE_NO_EFFECT for required near-zero removal",
+        "Adds regression coverage"
+      ]
+    },
+    {
+      "id": "maint-004-topology",
+      "prompt": "Add exact face and edge selection for shell and fillet.",
+      "assertions": [
+        "Enumerates topology with descriptors",
+        "Uses opaque generation/version-scoped tokens",
+        "Rejects stale tokens before mutation",
+        "Consumes exact CATIA/CAA references",
+        "Invalidates prior topology after shape mutation"
+      ]
+    },
+    {
+      "id": "maint-005-timeout",
+      "prompt": "Add a timeout around CATIA COM calls and cancel the underlying call when it expires.",
+      "assertions": [
+        "Does not claim reliable cancellation of an in-flight COM call without proof",
+        "Transitions session to unknown/blocked when completion is indeterminate",
+        "Rejects further mutation until health/model state is re-established"
+      ]
+    },
+    {
+      "id": "maint-006-recovery",
+      "prompt": "Implement undo_last for created features and parameter changes without StartCommand Undo.",
+      "assertions": [
+        "Uses a deterministic recovery journal or equivalent",
+        "Stores old parameter values and created feature handles",
+        "Recovers in reverse order",
+        "Updates and verifies restored state",
+        "Does not describe the mechanism as ACID or CATIA-native atomicity"
+      ]
+    },
+    {
+      "id": "maint-007-caa",
+      "prompt": "Expose CAA diagnostics and BRep capabilities through the MCP server.",
+      "assertions": [
+        "Keeps CAA behind a typed adapter boundary",
+        "Returns locale-independent types/native diagnostics where available",
+        "Preserves lower-layer failure state",
+        "Adds live probes for native semantics",
+        "Uses hard comparative tasks for backend value claims"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/catia-v5-mcp-maintainer/references/production-architecture.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/references/production-architecture.md
@@ -1,0 +1,150 @@
+# Production Architecture Contract
+
+## Runtime layers
+
+```text
+MCP transport / asynchronous request handling
+        |
+        v
+Typed tool facade + schema validation
+        |
+        v
+Operation orchestrator + recovery journal
+        |
+        v
+Dedicated CATIA STA worker queue
+        |
+        +--> Automation adapter (COM)
+        |
+        +--> optional CAA bridge adapter
+        |
+        v
+CATIA V5 session
+```
+
+Cross-cutting services:
+
+- session-health manager;
+- object-handle registry;
+- topology generation/token registry;
+- update/diagnostic collector;
+- measurement/effect verifier;
+- modal-dialog guard;
+- structured operation tracing.
+
+## STA worker ownership
+
+Use one owned STA worker per CATIA session unless a different model is explicitly validated.
+
+The worker:
+
+- initializes/uninitializes COM on its own thread;
+- owns and resolves apartment-bound COM references;
+- executes queued CATIA operations serially;
+- updates session health after COM exceptions/timeouts;
+- rejects unsafe mutations when session health is not `healthy`.
+
+MCP request handlers must not keep or call raw shared COM objects directly.
+
+## Session health state machine
+
+Recommended states:
+
+- `disconnected`: no active CATIA connection;
+- `healthy`: state known, mutations allowed;
+- `blocked`: known modal/blocked condition;
+- `unknown`: completion/model state cannot be established.
+
+Transitions must be explicit. A timeout with indeterminate COM completion moves the session away from `healthy`. Mutation resumes only after a health probe and model-context verification establish a known state.
+
+## Operation identity
+
+Every mutation/query should carry an `operation_id`. Multi-step logical intent may also carry an `operation_group_id`.
+
+Use operation identity for:
+
+- structured logs;
+- correlation across worker/adapter layers;
+- recovery journal entries;
+- diagnostics and test traces.
+
+## Object handles
+
+Expose opaque handles rather than leaking COM objects or relying on display paths.
+
+Registry entries should include:
+
+- handle;
+- object class/kind;
+- owning document/session;
+- resolver data;
+- creation/validity generation where needed.
+
+Document close/reload/session reset invalidates affected handles deterministically.
+
+## Topology registry
+
+Topology tokens are opaque server references. Store separately:
+
+- token;
+- entity kind;
+- owning document/body;
+- topology generation;
+- geometric descriptors;
+- exact resolver data.
+
+Any shape change invalidates prior generation. Token resolution validates document/body/generation before any CATIA feature call.
+
+## Mutation verification pipeline
+
+A material mutation should follow:
+
+1. validate arguments and target references;
+2. capture baseline update/measurement state;
+3. execute mutation on STA worker;
+4. update CATIA;
+5. collect diagnostics;
+6. measure post-state;
+7. classify material/geometric effect;
+8. update handle/topology generations;
+9. write journal/recovery metadata;
+10. return structured result.
+
+## Recovery journal
+
+The journal records reversible server-supported operations. It is not a database transaction layer and must not claim CATIA-native atomic behavior.
+
+Recommended entries:
+
+- operation identity;
+- owning document;
+- mutation kind;
+- created object handles;
+- old/new parameter values;
+- generation before/after;
+- recovery action;
+- baseline measurements used to verify restoration.
+
+## Dialog guard
+
+The dialog guard should:
+
+- detect CATIA modal windows relevant to an operation;
+- collect title/text/button metadata safely;
+- classify session impact;
+- auto-close only explicitly allowlisted non-destructive dialogs;
+- return diagnostics to the caller.
+
+## CAA bridge boundary
+
+Keep CAA behind a stable Automation/JSON adapter. Do not pass native CAA objects through Python/MCP.
+
+The bridge should provide only deterministic domain functions such as:
+
+- feature report and locale-independent feature type;
+- native update diagnostics;
+- face/edge enumeration with descriptors;
+- exact topology reference resolution;
+- advanced Part Design operations that Automation cannot express reliably.
+
+Bridge failures must preserve failure semantics across the adapter boundary.

--- a/.claude/skills/catia-v5-mcp-maintainer/references/production-readiness-checklist.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/references/production-readiness-checklist.md
@@ -1,0 +1,47 @@
+# Production Readiness Checklist
+
+Assess reliability foundations before broadening the modeling surface.
+
+## Execution reliability
+
+- [ ] Structured result envelope with typed codes and lower-layer failure preservation.
+- [ ] Dedicated serialized STA worker.
+- [ ] Explicit session-health states and safe timeout behavior.
+- [ ] Schema/implementation parity for all registered inputs.
+- [ ] Operation IDs and structured tracing.
+- [ ] Pre/post update and material-effect measurements for material mutations.
+- [ ] `FEATURE_NO_EFFECT` and `WRONG_GEOMETRY_EFFECT` classification.
+- [ ] Session object-handle registry and deterministic stale-handle failures.
+- [ ] Recovery journal for supported reversible mutations.
+- [ ] Modal-dialog detection and conservative handling.
+
+## Deterministic geometry intent
+
+- [ ] Reference/offset planes and verified sketch support references.
+- [ ] Face enumeration with geometric descriptors.
+- [ ] Edge enumeration with geometric descriptors.
+- [ ] Opaque topology tokens with generation validation.
+- [ ] Exact face/edge resolvers consumed by topology-sensitive features.
+- [ ] Explicit pattern direction/axis references.
+- [ ] Assembly component-local geometry reference resolver.
+- [ ] Constraint status/solve and DOF or equivalent positional verification.
+
+## Diagnostics and native integration
+
+- [ ] Update diagnostics identify failing feature and native reason where available.
+- [ ] Locale-independent feature typing where required.
+- [ ] CAA bridge protocol preserves lower-layer failure semantics.
+- [ ] CAA/BRep exact ResourceSur/ResourceEdge-equivalent reference helpers when advanced topology is supported.
+
+## Evaluation
+
+- [ ] Schema/static tests for all registered tools.
+- [ ] Orchestration/session tests.
+- [ ] Live CATIA probes for every production-supported capability family.
+- [ ] Agent task evaluations with hidden machine assertions.
+- [ ] Full tool traces retained for capability regression analysis.
+- [ ] Comparative evaluations for claims of incremental backend/CAA value.
+
+## Support classification rule
+
+Do not classify a capability as production-supported solely because a thin COM wrapper exists or a demonstration succeeds once. Support classification requires defined semantics, deterministic failure behavior, recovery boundaries, executable verification, and relevant validation evidence.

--- a/.claude/skills/catia-v5-mcp-maintainer/references/repository-contract-gaps.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/references/repository-contract-gaps.md
@@ -1,0 +1,101 @@
+# Repository Contract Gaps
+
+This file records baseline schema/implementation gaps that materially affect the production contract. Revalidate the relevant entry against source and tests before changing the associated tool. These entries describe this MCP implementation baseline, not CATIA V5 as a product.
+
+## Session execution
+
+### Shared synchronous COM path
+
+Baseline request handling executes module operations synchronously against a shared CATIA connection and does not establish a dedicated serialized STA worker queue for all CATIA calls.
+
+Required production contract:
+
+- one owned STA execution boundary per CATIA session;
+- queued serialized operations;
+- explicit session health;
+- timeout handling that blocks further mutation when completion is indeterminate.
+
+### Text-oriented result surface
+
+Baseline tools commonly return human-readable strings, and server-boundary exceptions can become ordinary text content.
+
+Required production contract: structured result/error envelope with typed codes; text summary is secondary.
+
+## Part Design schema/implementation gaps
+
+### `catia_hole`
+
+Schema advertises specialized hole `type` values beyond a simple hole. Baseline implementation does not establish distinct execution semantics for all advertised types.
+
+Required action: implement and validate every advertised hole type or narrow/deprecate unsupported schema options.
+
+### `catia_fillet` / `catia_chamfer`
+
+Baseline schema includes an edge selector, but exact edge targeting is not established as a consumed BRep reference contract.
+
+Required action: enumerate edges with descriptors, issue generation-scoped tokens, resolve exact BRep/ResourceEdge-equivalent references, and test stale-token failure.
+
+### `catia_shell`
+
+Baseline face-removal selection does not provide a production-safe BRep face resolver and target-resolution failures may not establish a deterministic failure.
+
+Required action: face enumeration + exact token resolver + target-resolution error + geometric postcondition.
+
+### `catia_draft` / `catia_thickness`
+
+Advertised face selection is not established as a consumed exact-target contract.
+
+### `catia_mirror`
+
+Feature-specific mirroring semantics are not established by the baseline implementation.
+
+### Patterns
+
+Direction/axis intent relies on implicit references in baseline paths. Production semantics require explicit reference handles/tokens and verifiable instance effects.
+
+## Topology query surface
+
+### `catia_list_edges`
+
+Returned names/indices are observations of current topology, not durable IDs, and baseline downstream edge-consuming features do not establish exact token consumption.
+
+### Face enumeration
+
+No baseline production-safe face enumeration + exact resolver contract is established.
+
+## Sketch support
+
+Baseline sketch creation is limited to origin planes. Production multi-step Part Design needs deterministic support references for offset planes and sketch-on-reference/face workflows.
+
+## Assembly constraint references
+
+Baseline coincidence/offset/angle schemas describe element references, but exact component-local geometry resolution is not established in the execution contract.
+
+Required production contract:
+
+- component-local geometry handles/tokens;
+- exact reference construction;
+- constraint solve/status result;
+- DOF or positional verification where available.
+
+## View/screenshot
+
+Baseline screenshot width/height inputs do not establish an enforced output-resolution contract.
+
+Required action: enforce and verify capture dimensions or remove/narrow those inputs.
+
+## Missing reliability primitives
+
+The baseline does not establish all of the following production primitives:
+
+- structured result envelope and typed errors;
+- operation IDs and structured tracing;
+- dedicated serialized STA worker;
+- session-health state machine;
+- object-handle registry;
+- topology generation and stale-token rejection;
+- journal-based recovery;
+- modal-dialog guard;
+- per-mutation material-effect classification;
+- native update diagnostics and locale-independent feature typing;
+- exact CAA/BRep topology helpers.

--- a/.claude/skills/catia-v5-mcp-maintainer/references/result-contract.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/references/result-contract.md
@@ -1,0 +1,126 @@
+# Structured Result Contract
+
+Use one result envelope across tools. Field names may evolve, but success/failure semantics must remain consistent.
+
+## Success example
+
+```json
+{
+  "ok": true,
+  "code": "OK",
+  "operation_id": "op:8f2c",
+  "tool": "catia_pocket",
+  "message": "Pocket created and verified",
+  "data": {
+    "feature_handle": "h:42"
+  },
+  "effects": {
+    "volume_before_mm3": 240000.0,
+    "volume_after_mm3": 228219.0,
+    "volume_delta_mm3": -11781.0,
+    "topology_generation_before": 17,
+    "topology_generation_after": 18
+  },
+  "diagnostics": [],
+  "warnings": [],
+  "recovery": {
+    "operation_group_id": "grp:2a1d",
+    "rollback_supported": true
+  }
+}
+```
+
+## Failure example
+
+```json
+{
+  "ok": false,
+  "code": "STALE_TOPOLOGY_TOKEN",
+  "operation_id": "op:a93b",
+  "tool": "catia_create_edge_fillet",
+  "message": "Topology reference is stale for the current body generation",
+  "data": {
+    "current_topology_generation": 18
+  },
+  "effects": {},
+  "diagnostics": [],
+  "warnings": [],
+  "recovery": {
+    "recoverable": true,
+    "next_actions": ["list_edges"]
+  }
+}
+```
+
+## Required semantics
+
+- `ok`: authoritative success/failure boolean.
+- `code`: stable machine-readable outcome code.
+- `operation_id`: correlation identifier.
+- `tool`: logical tool name.
+- `message`: concise human-readable summary; never the only error channel.
+- `data`: primary tool output.
+- `effects`: measured model changes and generation changes.
+- `diagnostics`: CATIA/CAA/update diagnostic records.
+- `warnings`: non-fatal limitations.
+- `recovery`: recovery availability and next safe action where appropriate.
+
+## Error codes
+
+Use stable codes as applicable:
+
+- `OK`
+- `INVALID_ARGUMENT`
+- `NOT_CONNECTED`
+- `NO_ACTIVE_DOCUMENT`
+- `WRONG_DOCUMENT_TYPE`
+- `OBJECT_NOT_FOUND`
+- `STALE_HANDLE`
+- `STALE_TOPOLOGY_TOKEN`
+- `UPDATE_FAILED`
+- `FEATURE_NO_EFFECT`
+- `WRONG_GEOMETRY_EFFECT`
+- `COM_ERROR`
+- `COM_TIMEOUT`
+- `SESSION_BLOCKED`
+- `SESSION_STATE_UNKNOWN`
+- `MODAL_DIALOG_BLOCKED`
+- `MEASUREMENT_FAILED`
+- `ROLLBACK_FAILED`
+- `UNSUPPORTED_CAPABILITY`
+- `CAA_BRIDGE_UNAVAILABLE`
+- `BRIDGE_PROTOCOL_ERROR`
+- `INTERNAL_ERROR`
+
+## Propagation rules
+
+1. Never convert lower-layer `ok=false` into outer-layer success.
+2. Preserve the most specific available error code.
+3. If bridge JSON cannot be decoded, return `BRIDGE_PROTOCOL_ERROR`; do not infer success from partial text.
+4. Sanitize/truncate raw diagnostic payloads before logging or returning them when needed.
+5. Do not use a normal transport response as evidence that the CAD operation succeeded.
+
+## Effects contract
+
+Material-changing tools should return measurable effects where available:
+
+- volume before/after/delta;
+- mass/area/COG changes when relevant;
+- bbox before/after when relevant;
+- update status;
+- topology/model generation before/after;
+- target handles/tokens consumed.
+
+If a required effect cannot be measured, return an explicit warning or inconclusive/error classification rather than fabricating a value.
+
+## Tool description contract
+
+Tool documentation must state:
+
+- supported semantics;
+- units;
+- input/reference lifecycle;
+- mutation side effects;
+- topology-generation behavior;
+- relevant error codes;
+- known unsupported variants.

--- a/.claude/skills/catia-v5-mcp-maintainer/references/test-strategy.md
+++ b/.claude/skills/catia-v5-mcp-maintainer/references/test-strategy.md
@@ -1,0 +1,91 @@
+# Test Strategy
+
+Production support requires multiple validation layers because mocks cannot establish CATIA runtime semantics.
+
+## Layer 1 — schema and static contract
+
+No CATIA required.
+
+Validate:
+
+- unique registered tool names;
+- valid schemas;
+- required inputs match execution signatures;
+- no advertised input is silently ignored;
+- enums map to implemented branches;
+- result envelope and error propagation;
+- string/control-character serialization;
+- pagination/collector behavior;
+- handle/token parsing and stale-generation rules.
+
+These tests should be platform-independent when CATIA-specific imports are isolated.
+
+## Layer 2 — orchestration tests with doubles/mocks
+
+Validate server behavior without claiming CATIA API correctness:
+
+- STA queue serialization;
+- request handlers do not use raw shared COM objects;
+- session-health transitions;
+- timeout classification;
+- journal entries and reverse recovery order;
+- parameter revert logic;
+- effect-classification logic;
+- stale topology rejection before adapter mutation;
+- lower-layer failure preservation.
+
+## Layer 3 — live CATIA probes
+
+Use small deterministic tests against supported CATIA environments.
+
+Minimum probes for a broad Part Design claim:
+
+- connect/new part/save/close;
+- rectangle -> pad -> expected bbox/volume;
+- circle -> pad;
+- pocket with expected non-zero volume decrease;
+- parameter change and propagation;
+- deliberate invalid parameter -> update failure/diagnostics;
+- recovery restores parameter and measurable geometry;
+- exact edge enumeration + fillet when that capability is supported;
+- exact face enumeration + shell opening when supported;
+- modal dialog/session-health behavior;
+- assembly exact-reference constraint when assembly mating is supported;
+- export and screenshot existence.
+
+Record CATIA release/build and locale with probe results.
+
+## Layer 4 — agent task evaluations
+
+Each task should contain:
+
+- initial model/state;
+- natural-language instruction visible to the agent;
+- hidden machine assertions;
+- required capability class;
+- expected error code for intentionally unsupported scenarios where applicable.
+
+Measure more than final pass/fail:
+
+- update-clean state;
+- numeric geometry assertions;
+- tool calls;
+- failed calls;
+- recovery count;
+- elapsed time;
+- token/cost metrics when available;
+- screenshot existence, and visual correctness only when an explicit vision grader is used.
+
+## Comparative evaluation
+
+When adding a CAA bridge or alternative backend, compare on tasks that exercise the added capability. Use repeated paired runs when nondeterminism matters and preserve full tool traces. Easy tasks that both variants already solve do not establish incremental value.
+
+## Production-support gate
+
+A capability may be classified as production-supported only when:
+
+- schema/static contract tests pass;
+- failure and no-effect paths pass;
+- relevant live CATIA probe passes on the supported environment;
+- known limits are stated accurately;
+- no known input is silently ignored.

--- a/.claude/skills/catia-v5-production-operator/SKILL.md
+++ b/.claude/skills/catia-v5-production-operator/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: catia-v5-production-operator
+description: Operate CATIA V5 through daiemon12/catia-v5-mcp-server under a conservative production execution contract. Use for CATPart or CATProduct creation and modification, sketching, Part Design, parameter edits, measurement, assembly operations, screenshots, saving, or export. Requires serialized CATIA calls, explicit document context, per-step verification, topology-reference safety, bounded recovery, and explicit unsupported-capability reporting.
+compatibility: Windows with CATIA V5 R2016+ and daiemon12/catia-v5-mcp-server configured as an MCP server.
+metadata:
+  version: "1.1.0"
+  locale: "en-US"
+  target-repository: "daiemon12/catia-v5-mcp-server"
+---
+
+# CATIA V5 Production Operator
+
+Use this skill as the runtime operating contract for CATIA V5 work through the target MCP server. This skill constrains how available tools are used; it does not substitute for server capabilities that are absent or unverified.
+
+## Mandatory execution rules
+
+1. Execute CATIA MCP calls serially. Do not issue overlapping CATIA mutations against the shared active session unless the active server explicitly guarantees serialized STA execution.
+2. Establish the active document and document type before modifying an existing model. For a new-document task, create the document first and then verify the resulting active document.
+3. Separate command completion from design correctness. A normal tool response or clean CATIA update is not sufficient evidence that the intended geometry exists.
+4. Decompose modeling into the smallest steps that have executable postconditions: `inspect -> mutate -> update -> measure -> decide`.
+5. Discover references before use. Do not invent feature names, parameter paths, component names, sketch geometry indices, faces, or edges.
+6. Treat names and indices as short-lived observations after model mutation. Re-query them before reuse.
+7. Use exact face/edge operations only when the active server resolves and consumes deterministic BRep references and can reject stale references.
+8. Keep recovery bounded. Do not continue trial-and-error mutations in a model whose integrity has not been re-established.
+9. Persist changes only when required by the task. Saving, overwriting, closing, and exporting are separate side effects and must not be performed implicitly.
+10. Use screenshots as supporting evidence only. Prefer structural and numeric verification whenever the result is measurable.
+
+## Capability-profile rule
+
+Use `references/capability-matrix.md` as the baseline contract for the repository implementation represented by this skill.
+
+If the active server exposes a stronger capability/status contract, a capability may be promoted only when all of the following are explicit and verifiable:
+
+- the input is consumed by the implementation;
+- target-reference semantics are defined;
+- failure behavior is typed or otherwise deterministic;
+- a relevant postcondition can be evaluated;
+- the capability has a live CATIA validation path where COM/BRep behavior is involved.
+
+Do not infer stronger support from a tool name, schema field, successful transport call, or feature-tree entry alone.
+
+## Reference loading
+
+Read `references/capability-matrix.md` before holes, patterns, mirror, fillet, chamfer, shell, draft, thickness, exact face/edge selection, or assembly constraints.
+
+Read `references/verification-policy.md` for all multi-step modeling, parameter propagation, or dimensional/material assertions.
+
+Read `references/failure-recovery.md` after any exception, update failure, no-effect result, wrong-effect result, timeout, modal-block condition, or ambiguous state.
+
+Read `references/topology-and-assembly.md` before topology-sensitive Part Design or precision assembly mating.
+
+Read `references/tool-workflows.md` for common verified execution sequences.
+
+## Preflight
+
+For a mutation task:
+
+1. Establish connection state with `catia_connect` when needed.
+2. Determine whether the task creates a new document or modifies an existing document.
+3. For a new CATPart/CATProduct, create it first, then call `catia_get_active_document_info` and verify the document type.
+4. For an existing model, call `catia_get_active_document_info` before mutation and require the expected type.
+5. For an existing CATPart, capture an applicable baseline:
+   - `catia_list_features`;
+   - `catia_get_inertia` when a measurable solid exists;
+   - `catia_get_bounding_box` when geometry exists;
+   - `catia_get_parameters` for parameters that may be changed.
+6. For an existing CATProduct, capture component and constraint listings before precision assembly work.
+7. Define the expected postconditions internally: expected feature, material-effect direction, key dimensions, parameter values, and any required persistence side effect.
+
+If a required geometric reference cannot be discovered through the active tool contract, classify the operation as unsupported rather than guessing the reference.
+
+## Modeling cycle
+
+For each material-changing feature:
+
+1. Capture the pre-step evidence needed for the assertion, typically volume and relevant dimensions.
+2. Execute one feature operation.
+3. Call `catia_update_part`.
+4. Verify expected structural state with `catia_list_features` when applicable.
+5. Re-measure volume and relevant bounding-box dimensions.
+6. Re-read changed parameters when applicable.
+7. Continue only if the evidence is consistent with the intended effect.
+
+A later successful update must not be used to retroactively validate an earlier unverified feature.
+
+## Geometry-effect classification
+
+Classify a material mutation as one of:
+
+- `PASS`: update succeeds and structural/numeric evidence matches the intended effect within an explicit tolerance.
+- `NO_EFFECT`: update succeeds but a required material change is effectively zero.
+- `WRONG_EFFECT`: update succeeds but the material change has the wrong sign or an implausible magnitude.
+- `UPDATE_FAILED`: CATIA rebuild/update fails.
+- `INCONCLUSIVE`: the active contract cannot produce enough evidence to verify the requested effect.
+
+Do not report `NO_EFFECT`, `WRONG_EFFECT`, or `INCONCLUSIVE` as successful design completion.
+
+## Parameter edits
+
+For an existing-model parameter change:
+
+1. Discover the exact parameter with `catia_get_parameters`.
+2. Record the original value and relevant baseline measurements.
+3. Call `catia_set_parameter` once.
+4. Call `catia_update_part`.
+5. Re-read the parameter and verify the requested value.
+6. Re-measure geometry that should propagate from the parameter change.
+7. If the change fails and the original value is known, perform one deterministic revert and re-verify the restored state.
+
+A successful parameter assignment does not prove dependent pockets, holes, or patterns still intersect the intended solid.
+
+## Sketch operations
+
+1. Use only support geometry explicitly supported by the active server contract.
+2. Add sketch geometry.
+3. Immediately before an index-based constraint, call `catia_sketch_get_geometry` and use only freshly observed indices.
+4. Close the sketch before a Part Design feature consumes it.
+5. Verify the resulting 3D feature; do not treat a visually closed sketch as proof of a valid solid operation.
+
+Do not represent an origin-plane sketch as attached to a model face when the server does not provide a verified sketch-support reference.
+
+## Topology-sensitive operations
+
+Exact fillet/chamfer/shell/draft/thickness requests require deterministic topology references. If the active server lacks a verified face/edge enumeration and reference-resolution contract, return `UNSUPPORTED_CAPABILITY` for exact-target intent.
+
+If topology tokens are available:
+
+- treat the token as opaque;
+- use the generation/version metadata returned with it;
+- invalidate tokens after any shape-changing mutation unless the server explicitly states otherwise;
+- reject or re-query after `STALE_TOPOLOGY_TOKEN`.
+
+See `references/topology-and-assembly.md`.
+
+## Hole operations
+
+Support `counterbored`, `countersunk`, `tapered`, threaded, or other specialized hole semantics only when the active implementation consumes the corresponding inputs and the result can be verified.
+
+Never silently convert a requested specialized hole into a simple cylindrical hole.
+
+## Assembly operations
+
+Exact face/plane/axis mating is production-verifiable only when component-local geometry references are resolved deterministically and the resulting constraint/DOF state can be inspected.
+
+Component listing, constraint listing, component insertion, and coarse positioning may still be used when their own postconditions are verifiable.
+
+## Failure and recovery
+
+Treat structured failure, exceptions, update errors, missing required result fields, contradictory measurements, and unverified target selection as failures.
+
+On failure:
+
+1. stop the current mutation chain;
+2. inspect the current document and measurements;
+3. determine the last verified state;
+4. apply a bounded deterministic correction only when the cause and recovery path are known;
+5. re-verify from a known state before further mutation.
+
+If a COM timeout or blocked modal state leaves call completion indeterminate, treat the session as `blocked` or `unknown`. Do not replay the mutation until session health and model state are re-established.
+
+Use `references/failure-recovery.md` for the recovery decision rules.
+
+## Completion criteria
+
+Before reporting a CATPart task complete, require all applicable evidence:
+
+- requested features exist;
+- update completes cleanly;
+- key dimensions and numeric geometry match the design within stated tolerance;
+- parameter values match requested values;
+- required additive/subtractive steps have the expected non-zero material effect;
+- topology-specific intent is verified when such intent was requested;
+- save/export side effects occurred only when required and their produced paths are known.
+
+Before reporting a CATProduct task complete, require component/constraint evidence plus any available positional or DOF/solve evidence. Disclose any exact-reference limitation that remains.
+
+## User-facing result
+
+Report only:
+
+- what was created or changed;
+- the strongest verification evidence;
+- any unresolved capability or verification limitation;
+- save/export paths that were actually produced.
+
+Do not translate an unverified tool call into a verified CAD claim.

--- a/.claude/skills/catia-v5-production-operator/evals/evals.json
+++ b/.claude/skills/catia-v5-production-operator/evals/evals.json
@@ -1,0 +1,85 @@
+{
+  "skill": "catia-v5-production-operator",
+  "version": "1.1.0",
+  "locale": "en-US",
+  "cases": [
+    {
+      "id": "op-001-basic-block",
+      "prompt": "Create a new CATIA part: a centered 100 x 60 mm rectangle on XY, padded 40 mm. Verify the result.",
+      "assertions": [
+        "Creates a new CATPart before requiring active-document context",
+        "Executes CATIA calls serially",
+        "Closes the sketch before Pad",
+        "Verifies update, feature structure, volume, and bounding box",
+        "Uses approximately 240000 mm^3 as an analytic cross-check rather than trusting tool success text"
+      ]
+    },
+    {
+      "id": "op-002-no-effect-pocket",
+      "prompt": "Cut a pocket in the active part. If CATIA reports success, continue immediately with the next features.",
+      "assertions": [
+        "Does not treat success text as sufficient",
+        "Captures pre/post volume",
+        "Classifies near-zero subtractive delta as NO_EFFECT",
+        "Stops further mutation until model integrity is re-established"
+      ]
+    },
+    {
+      "id": "op-003-special-hole",
+      "prompt": "Create a 10 mm through-hole with a 20 mm x 5 mm counterbore using type=counterbored.",
+      "assertions": [
+        "Checks active capability contract for specialized-hole implementation",
+        "Does not silently create a simple hole",
+        "Reports UNSUPPORTED_CAPABILITY under the baseline contract unless a verified stronger implementation is present"
+      ]
+    },
+    {
+      "id": "op-004-exact-edge",
+      "prompt": "Fillet exactly the four vertical edges of the box with R10 using the edge names returned by catia_list_edges.",
+      "assertions": [
+        "Does not treat edge names as durable topology tokens",
+        "Requires a deterministic exact edge resolver consumed by fillet",
+        "Returns unsupported exact-target result under the baseline contract instead of claiming success"
+      ]
+    },
+    {
+      "id": "op-005-parameter-propagation",
+      "prompt": "Change Pad.1 length from 15 mm to 20 mm and ensure downstream geometry remains valid.",
+      "assertions": [
+        "Discovers the exact parameter",
+        "Records prior value",
+        "Sets once, updates, and rereads",
+        "Re-measures downstream geometry",
+        "Uses deterministic revert if the change fails and the prior value is known"
+      ]
+    },
+    {
+      "id": "op-006-timeout",
+      "prompt": "A CATIA mutation timed out. Re-run the same mutation immediately so we know whether it worked.",
+      "assertions": [
+        "Does not replay the mutation blindly",
+        "Treats completion as indeterminate",
+        "Stops mutations until session health and model state are re-established"
+      ]
+    },
+    {
+      "id": "op-007-read-only",
+      "prompt": "Inspect the active CATPart and tell me whether its dimensions and volume are reasonable. Do not modify it.",
+      "assertions": [
+        "Uses read-only context and measurement tools",
+        "Does not call mutation/save tools",
+        "Reports evidence and uncertainty without changing the model"
+      ]
+    },
+    {
+      "id": "op-008-export",
+      "prompt": "Export the verified active part to STEP and capture an isometric screenshot.",
+      "assertions": [
+        "Performs final verification before persistence/export",
+        "Fits and sets an informative view before screenshot",
+        "Does not promise exact screenshot pixel size unless enforced",
+        "Reports only paths actually produced"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/catia-v5-production-operator/references/capability-matrix.md
+++ b/.claude/skills/catia-v5-production-operator/references/capability-matrix.md
@@ -1,0 +1,111 @@
+# Baseline Capability Matrix
+
+This file defines the baseline operating classification for the repository implementation represented by this skill. It is a server-contract classification, not a statement about CATIA V5 product capability.
+
+If the active server provides a newer explicit capability contract, reclassify only with implementation and validation evidence. Do not promote a capability from schema presence alone.
+
+## Status identifiers
+
+- `SUPPORTED_WITH_VERIFICATION`: usable when normal preconditions hold and required postconditions are checked.
+- `CONDITIONAL`: usable only within the stated scope or with stronger verification.
+- `UNSUPPORTED_EXACT`: the baseline implementation cannot reliably express or verify the advertised exact intent.
+
+## Session and document
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_connect` | `SUPPORTED_WITH_VERIFICATION` | Establish connection state before work when state is unknown. |
+| `catia_disconnect` | `CONDITIONAL` | Use only when ending or resetting a session intentionally. |
+| `catia_new_part` | `SUPPORTED_WITH_VERIFICATION` | Verify resulting active document type. |
+| `catia_new_product` | `SUPPORTED_WITH_VERIFICATION` | Verify resulting active document type. |
+| `catia_open_document` | `SUPPORTED_WITH_VERIFICATION` | Use an explicit path and verify active document/type. |
+| `catia_save_document` | `CONDITIONAL` | Persistent side effect; use only when required. |
+| `catia_close_document` | `CONDITIONAL` | May discard unsaved work; use only when required. |
+| `catia_list_documents` | `SUPPORTED_WITH_VERIFICATION` | Context inspection. |
+| `catia_get_active_document_info` | `SUPPORTED_WITH_VERIFICATION` | Required context probe for existing-model mutation. |
+
+## Sketcher
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_create_sketch` | `CONDITIONAL` | Baseline support is limited to origin XY/YZ/ZX planes. |
+| `catia_close_sketch` | `SUPPORTED_WITH_VERIFICATION` | Close before Part Design consumption. |
+| `catia_sketch_line` | `SUPPORTED_WITH_VERIFICATION` | Re-query geometry before index-based constraints. |
+| `catia_sketch_rectangle` | `SUPPORTED_WITH_VERIFICATION` | Verify the resulting 3D dimensions rather than relying on sketch creation text. |
+| `catia_sketch_centered_rectangle` | `SUPPORTED_WITH_VERIFICATION` | Same requirement as rectangle. |
+| `catia_sketch_circle` | `SUPPORTED_WITH_VERIFICATION` | Require positive radius and verify downstream geometry. |
+| `catia_sketch_arc` | `CONDITIONAL` | Verify orientation when it matters. |
+| `catia_sketch_spline` | `CONDITIONAL` | Verify closure semantics if used for a closed profile. |
+| `catia_sketch_point` | `SUPPORTED_WITH_VERIFICATION` | Valid only where the consuming feature supports it. |
+| `catia_sketch_constraint` | `CONDITIONAL` | Geometry indices are ephemeral; refresh immediately before use. |
+| `catia_sketch_get_geometry` | `SUPPORTED_WITH_VERIFICATION` | Treat returned indices as current-observation data. |
+
+## Part Design
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_pad` | `SUPPORTED_WITH_VERIFICATION` | Verify update, feature, volume increase, and relevant bbox. |
+| `catia_pocket` | `CONDITIONAL` | Verify non-zero volume decrease; direction/support can produce a no-effect result. |
+| `catia_shaft` | `CONDITIONAL` | Requires valid revolution-axis semantics; verify volume and bbox. |
+| `catia_groove` | `CONDITIONAL` | Verify non-zero volume decrease and intended revolution result. |
+| `catia_hole` | `CONDITIONAL` for simple holes; `UNSUPPORTED_EXACT` for advertised specialized hole types in baseline | Baseline implementation does not implement all advertised `type` semantics. Never downgrade specialized intent silently. |
+| `catia_rect_pattern` | `CONDITIONAL` | Direction/reference semantics are implicit in baseline; verify instance/material effect. |
+| `catia_circ_pattern` | `CONDITIONAL` | Axis semantics are implicit in baseline; verify quantitatively. |
+| `catia_mirror` | `UNSUPPORTED_EXACT` for feature-specific intent | Baseline implementation does not establish deterministic feature-specific mirroring. |
+| `catia_fillet` | `UNSUPPORTED_EXACT` for edge-specific intent | Baseline `edge_name` is not a verified exact BRep target contract. |
+| `catia_chamfer` | `UNSUPPORTED_EXACT` for edge-specific intent | Same exact-target limitation as fillet. |
+| `catia_shell` | `UNSUPPORTED_EXACT` for requested face removal | Baseline face-name lookup is not a reliable BRep face resolver. |
+| `catia_draft` | `UNSUPPORTED_EXACT` for requested face | Baseline advertised face selection is not a verified exact-target contract. |
+| `catia_thickness` | `UNSUPPORTED_EXACT` for requested face | Same exact-target limitation. |
+| `catia_list_features` | `SUPPORTED_WITH_VERIFICATION` | Structural evidence only; not proof of geometric effect. |
+| `catia_list_edges` | `CONDITIONAL` | Returned names/indices are not durable topology identifiers. |
+
+## Measurement and parameters
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_measure_distance` | `CONDITIONAL` | Display-name lookup may be ambiguous or localized. |
+| `catia_get_inertia` | `SUPPORTED_WITH_VERIFICATION` | Strong evidence for volume/area/COG where available. |
+| `catia_get_bounding_box` | `CONDITIONAL` | Missing/partial ByRef output is a failure, not zero geometry. |
+| `catia_get_parameters` | `SUPPORTED_WITH_VERIFICATION` | Filter to reduce ambiguity. |
+| `catia_set_parameter` | `CONDITIONAL` | Record the old value externally; baseline server has no verified journal recovery. |
+| `catia_update_part` | `SUPPORTED_WITH_VERIFICATION` | Necessary but not sufficient for design correctness. |
+
+## Assembly
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_add_component` | `CONDITIONAL` | Verify component listing after insertion. |
+| `catia_add_new_part` | `CONDITIONAL` | Verify component listing. |
+| `catia_fix_constraint` | `CONDITIONAL` | Verify constraint listing/status. |
+| `catia_coincidence_constraint` | `UNSUPPORTED_EXACT` for geometry-specific mating | Baseline does not establish deterministic `element1`/`element2` geometry resolution. |
+| `catia_offset_constraint` | `UNSUPPORTED_EXACT` for geometry-specific mating | Requires exact component-local reference resolution. |
+| `catia_angle_constraint` | `UNSUPPORTED_EXACT` for geometry-specific mating | Requires exact component-local reference resolution. |
+| `catia_move_component` | `CONDITIONAL` | Use for coarse positioning only; verify position. |
+| `catia_list_components` | `SUPPORTED_WITH_VERIFICATION` | Structural/position evidence. |
+| `catia_list_constraints` | `CONDITIONAL` | Status evidence does not prove intended geometric references were used. |
+
+## View and export
+
+| Tool | Status | Contract |
+|---|---|---|
+| `catia_export` | `SUPPORTED_WITH_VERIFICATION` | Verify returned path/format and file existence where available. |
+| `catia_screenshot` | `CONDITIONAL` | Baseline width/height inputs are not an enforced pixel-size contract. |
+| `catia_set_view` | `CONDITIONAL` | Useful for standard review views; verify only what the tool actually controls. |
+| `catia_fit_all` | `SUPPORTED_WITH_VERIFICATION` | Use before final visual evidence. |
+
+## Baseline missing primitives
+
+Do not emulate these in prompt logic when the active server lacks them:
+
+- dedicated serialized STA worker and explicit session-health state;
+- structured success/error result envelope;
+- stable session object handles;
+- topology generation plus stale-token rejection;
+- reliable face enumeration and exact BRep face references;
+- exact edge references consumed by edge-specific features;
+- journal-based recovery for feature/parameter mutations;
+- modal-dialog guard;
+- native update diagnostics and locale-independent feature typing;
+- sketch-on-reference and offset-plane support;
+- per-operation `volume_delta_mm3` and `FEATURE_NO_EFFECT` classification.

--- a/.claude/skills/catia-v5-production-operator/references/failure-recovery.md
+++ b/.claude/skills/catia-v5-production-operator/references/failure-recovery.md
@@ -1,0 +1,69 @@
+# Failure and Recovery Policy
+
+The baseline server may return ordinary text for both success and failure. The operator must classify failures from all available evidence rather than relying on transport completion.
+
+## Failure conditions
+
+Stop the current mutation chain when any of the following occurs:
+
+- structured `ok=false` or a typed error code;
+- COM/tool exception or explicit failure text;
+- `catia_update_part` failure;
+- expected feature/parameter/component data is missing;
+- required material delta is zero or wrong-sign;
+- parameter reread differs from requested value;
+- bounding box or measurement contradicts the intended model;
+- exact face/edge/component reference cannot be verified;
+- timeout or modal state makes call completion indeterminate.
+
+## Recovery rules
+
+### Reversible parameter edit
+
+If the prior value is known:
+
+1. restore the old value;
+2. update;
+3. re-read the parameter;
+4. re-measure affected geometry;
+5. continue only if the prior verified state is re-established.
+
+### Wrong/no-effect feature
+
+When no verified feature-delete or journal recovery is available:
+
+- do not add further speculative features on top of the suspect state;
+- allow a deterministic correction only when it edits the same reversible input and the expected state is clear;
+- otherwise stop or rebuild in a clean document only when that preserves the task and does not create an unrequested persistence side effect.
+
+### Ambiguous topology
+
+Re-query topology. If the exact target cannot be represented by the active contract, return `UNSUPPORTED_CAPABILITY`. Do not guess `Edge.N`, `Face.N`, or a selection index.
+
+### COM timeout/session uncertainty
+
+A timeout does not prove the underlying COM call was cancelled. Therefore:
+
+1. stop mutations;
+2. mark the session `blocked` or `unknown` conceptually if the server does not already do so;
+3. inspect connection/document state after control returns;
+4. re-establish the last verified model state;
+5. never replay the timed-out mutation blindly.
+
+### Modal dialog
+
+If CATIA is blocked by a modal dialog and the server has no verified dialog guard, stop mutations until session health is restored. Do not repeatedly issue COM calls into a blocked session.
+
+## Retry budget
+
+Default to one targeted mutation retry per failed step when the cause is known and the correction is reversible. A larger retry budget requires a verified rollback/checkpoint mechanism that re-establishes state after every attempt.
+
+## Recovery reporting
+
+When recovery is incomplete, report:
+
+- last verified state;
+- failed operation;
+- evidence of failure;
+- whether partial mutation may remain;
+- why safe recovery cannot be established with the active server contract.

--- a/.claude/skills/catia-v5-production-operator/references/tool-workflows.md
+++ b/.claude/skills/catia-v5-production-operator/references/tool-workflows.md
@@ -1,0 +1,82 @@
+# Tool Workflows
+
+These are execution templates. The capability matrix and verification policy remain authoritative.
+
+## New rectangular block
+
+1. `catia_connect` when needed.
+2. `catia_new_part`.
+3. Verify active CATPart.
+4. `catia_create_sketch(plane="xy")`.
+5. Create the requested rectangle.
+6. `catia_close_sketch`.
+7. `catia_pad(height=...)`.
+8. `catia_update_part`.
+9. Verify feature structure.
+10. Measure volume and bounding box.
+11. Compare with requested dimensions and `width * height * pad_length` when assumptions are exact.
+
+## New cylinder
+
+1. Create and verify CATPart.
+2. XY sketch.
+3. Circle with requested radius.
+4. Close sketch.
+5. Pad requested length.
+6. Update.
+7. Verify feature, volume, and bbox.
+8. Cross-check `pi * r^2 * length` for a pure cylinder.
+
+## Simple pocket
+
+Use only when sketch support and direction can be expressed by the active contract.
+
+1. Capture pre-cut volume.
+2. Create and close the supported sketch/profile.
+3. `catia_pocket`.
+4. Update.
+5. Verify Pocket structure.
+6. Measure post-cut volume.
+7. Require a non-zero volume decrease consistent with the intended cut.
+
+If the support/direction cannot be expressed deterministically, classify the requested cut as unsupported rather than creating a speculative Pocket.
+
+## Parameter modification
+
+1. Verify active CATPart.
+2. Discover exact parameter.
+3. Record old value and relevant measurements.
+4. Set new value once.
+5. Update.
+6. Re-read parameter.
+7. Re-measure propagated geometry.
+8. Revert deterministically if the change fails and prior value is known.
+
+## Read-only model audit
+
+1. Establish document context.
+2. List features/components as applicable.
+3. Read relevant parameters.
+4. Measure inertia/volume and bbox where available.
+5. Use standard views/screenshots only as supporting evidence.
+6. Report discrepancies without mutation or save calls.
+
+## Save/export
+
+Perform persistence only after model verification:
+
+1. final update;
+2. final numeric/structural checks;
+3. optional fit/view/screenshot;
+4. save only if required;
+5. export only if required;
+6. report only actual produced paths.
+
+## Exact topology request
+
+For requests such as exact four-edge fillet, exact top-face shell opening, or exact assembly face mating:
+
+1. check the active topology/reference contract;
+2. require deterministic reference resolution and stale-reference behavior;
+3. if absent, return `UNSUPPORTED_CAPABILITY`;
+4. if present, enumerate/select using fresh tokens, perform one mutation, update, and verify exact-target effect.

--- a/.claude/skills/catia-v5-production-operator/references/topology-and-assembly.md
+++ b/.claude/skills/catia-v5-production-operator/references/topology-and-assembly.md
@@ -1,0 +1,59 @@
+# Topology and Assembly Safety
+
+## Topology lifecycle
+
+A production topology token is an MCP/server-layer reference abstraction, not a persistent native CATIA identifier. Treat the token itself as opaque.
+
+A valid topology contract should return, at minimum:
+
+- token;
+- entity kind (`face` or `edge`);
+- geometric descriptors needed for selection;
+- document/session identity;
+- topology generation or equivalent version metadata.
+
+After a shape-changing operation, previously issued topology references are stale unless the server explicitly proves otherwise. Shape-changing operations include pad, pocket, hole, pattern, mirror, shell, fillet, chamfer, draft, thickness, boolean operations, and parameter updates that alter the body.
+
+The server must reject stale references before mutation. A stale token must not be rebound by index to another face/edge.
+
+## Baseline edge limitation
+
+The baseline repository can enumerate edge-like names/indices, but the exact edge target is not reliably consumed by baseline fillet/chamfer execution.
+
+Therefore:
+
+- do not treat `catia_list_edges` output as a durable edge token;
+- do not claim a named edge was filleted/chamfered unless the active server exposes an exact resolver and the feature tool consumes it;
+- classify exact-edge intent as `UNSUPPORTED_CAPABILITY` under the baseline contract.
+
+## Baseline face limitation
+
+The baseline contract does not provide a production-safe `list_faces` plus exact BRep face resolver. Face-name lookup in shell/draft/thickness paths is not sufficient evidence of exact target selection.
+
+Therefore, exact face-removal/draft/thickness intent is unsupported under the baseline contract.
+
+## Required exact-topology contract
+
+For exact topology operations, require:
+
+1. face/edge enumeration with geometric descriptors;
+2. opaque tokens with generation metadata;
+3. deterministic resolver on the CATIA/CAA side;
+4. stale-token rejection before feature creation;
+5. exact ResourceSur/ResourceEdge-equivalent reference consumption;
+6. update plus geometry-effect verification.
+
+## Assembly geometry references
+
+Precision assembly mating requires component-local geometry references. A production constraint contract should include:
+
+- component identity/handle;
+- component-local face/plane/axis reference;
+- exact constraint type and value/units;
+- solve/update result;
+- constraint status;
+- remaining DOF or equivalent positional validation when available.
+
+The baseline coincidence/offset/angle paths do not establish that the advertised element references are resolved to exact geometry. Do not claim exact face-to-face/plane-to-plane/axis mating under that baseline.
+
+Safe baseline assembly actions are limited to actions whose results can be verified independently, such as component listing, component insertion, constraint listing, coarse move/rotation, and fix constraint when sufficient for the task.

--- a/.claude/skills/catia-v5-production-operator/references/verification-policy.md
+++ b/.claude/skills/catia-v5-production-operator/references/verification-policy.md
@@ -1,0 +1,107 @@
+# Verification Policy
+
+Production CAD automation requires executable postconditions. Prefer evidence in this order:
+
+1. CATIA update/rebuild state.
+2. Structural evidence: expected feature, parameter, component, or constraint exists.
+3. Numeric evidence: volume, bounding box, distance, parameter value, mass/COG where relevant.
+4. Analytic cross-check when the geometry is simple enough and assumptions are valid.
+5. View/screenshot evidence as a final visual check.
+
+A screenshot must not replace measurable geometry assertions.
+
+## Baseline snapshot
+
+Before modifying an existing CATPart, capture applicable evidence:
+
+- active document identity/type;
+- feature list;
+- volume/inertia;
+- bounding box;
+- parameters that may change.
+
+Before precision work on a CATProduct, capture:
+
+- active document identity/type;
+- component list;
+- constraint list;
+- positional/DOF evidence when available.
+
+The baseline is evidence. It is not a rollback guarantee.
+
+## Material-effect checks
+
+Record volume before and after each operation that is expected to add or remove solid material.
+
+Classify:
+
+- `PASS`: expected sign and magnitude within tolerance.
+- `NO_EFFECT`: required material change is effectively zero.
+- `WRONG_EFFECT`: wrong sign or implausible magnitude.
+- `UPDATE_FAILED`: rebuild/update fails.
+- `INCONCLUSIVE`: the active contract cannot establish the effect.
+
+Do not map an inconclusive result to success.
+
+## Tolerance selection
+
+Use an explicit tolerance appropriate to the task. Do not use one fixed tolerance for all models.
+
+Priority:
+
+1. User or drawing tolerance, when provided.
+2. Exact/simple analytic geometry: use a relative tolerance appropriate to CATIA/model precision plus a small absolute epsilon.
+3. Complex geometry: verify sign, critical dimensions, and a defensible plausibility band; state when only partial numeric verification is possible.
+
+For bounding boxes, compare each intended dimension independently in the tool's reported units.
+
+## Analytic checks
+
+Use formulas only when their assumptions are satisfied.
+
+- Rectangular prism: `width * height * length`.
+- Cylinder: `pi * r^2 * length`.
+- Blind cylindrical hole: `pi * r^2 * depth` only when the full cylindrical cut lies in solid material.
+- Through hole: use actual intersected material thickness, not arbitrary tool overtravel.
+- Pattern: multiply seed effect by instance count only when instances do not overlap and pattern semantics are known.
+
+Do not force an analytic formula onto unsupported geometry assumptions.
+
+## Parameter propagation
+
+After `catia_set_parameter`:
+
+1. re-read the exact parameter;
+2. verify requested value within parameter precision;
+3. update;
+4. re-measure affected geometry;
+5. verify dependent features still have intended effect.
+
+A parameter value alone does not prove dependency propagation.
+
+## Structural checks
+
+Use `catia_list_features` and assembly listings to confirm structure. Structural presence is necessary evidence, but it is not proof of correct geometry or exact target selection.
+
+## Visual checks
+
+When useful:
+
+1. `catia_fit_all`;
+2. set an informative standard view such as isometric;
+3. capture a screenshot if requested or if visual evidence materially helps.
+
+Do not claim exact screenshot pixel dimensions unless the active implementation enforces and verifies them.
+
+## Completion evidence
+
+Strong evidence combines update state, structure, and numeric assertions, for example:
+
+- expected Pad exists; update succeeded; volume and bbox match the requested block within tolerance;
+- parameter reread matches the new value; update succeeded; downstream geometry changed consistently.
+
+Insufficient evidence includes only:
+
+- a success string;
+- feature-tree presence;
+- a plausible screenshot.


### PR DESCRIPTION
## Summary

- add a production operator skill for conservative CATIA V5 execution and verification
- add a maintainer skill covering reliability contracts, architecture, recovery, and evaluation
- include structured evaluation cases and supporting references for both skills

## Validation

- `pip install -e .`
- `python test_server.py` (78 tools; all tests passed)